### PR TITLE
fix: remove disqus from post pages

### DIFF
--- a/post.hbs
+++ b/post.hbs
@@ -48,21 +48,6 @@
           {{/prev_post}}
         </div>
       </div>
-      <div class="comments">
-        <div id="disqus_thread"></div>
-        <script>
-          var disqus_config = function () {
-            this.page.url = '{{ url absolute="true" }}';
-            this.page.identifier = 'ghost-{{ comment_id }}';
-          };
-          (function () {
-            var d = document, s = d.createElement('script');
-            s.src = 'https://openmined.disqus.com/embed.js';
-            s.setAttribute('data-timestamp', +new Date());
-            (d.head || d.body).appendChild(s);
-          })();
-        </script>
-      </div>
       {{/ is }}
     </div>
   </div>


### PR DESCRIPTION
## Description

This PR removes Disqus entirely from blog posts.

When this is merged, it will not be possible to comment on blog posts via the website.

We must investigate another solution for commenting on posts if that feature is 100% immediately desired.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
